### PR TITLE
fix: docs: missing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ local ft = require("improved-ft")
 ft.setup({
   -- Maps default f/F/t/T/;/, keys
   -- default: false
-  use_default_mappings = true
+  use_default_mappings = true,
   -- Ignores case of interactively given characters.
   -- default: false
-  ignore_user_char_case = true
+  ignore_user_char_case = true,
 })
 ```
 
@@ -51,7 +51,7 @@ ft.setup({
 -- Jump forward pass a given by user character.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
-    direction = "forward"
+    direction = "forward",
     offset = "post",
     pattern = nil,
   })
@@ -75,7 +75,7 @@ end)
 -- Jump forward pass any quotes.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
-    direction = "forward"
+    direction = "forward",
     offset = "post",
     pattern = "\\v[\"'`]",
   })
@@ -99,7 +99,7 @@ end)
 -- Jump forward inside round brackets.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
-    direction = "forward"
+    direction = "forward",
     offset = "post",
     pattern = "\\M(",
   })
@@ -123,7 +123,7 @@ end)
 -- Jump forward inside / outside round brackets.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
-    direction = "forward"
+    direction = "forward",
     offset = "post",
     pattern = "\\v[()]",
     -- If you don't want to jump post ) that is the last character on the line.
@@ -149,7 +149,7 @@ end)
 -- Jump forward to a number.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
-    direction = "forward"
+    direction = "forward",
     offset = "none",
     pattern = "\\v\\d+",
   })

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ ft.setup({
 ```
 
 ### Additional configuration examples
-<details><summary>Jump pass a character</summary>
+<details><summary>Jump past a character</summary>
 
 ```lua
--- Jump forward pass a given by user character.
+-- Jump forward past a given by user character.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
     direction = "forward",
@@ -57,7 +57,7 @@ vim.keymap.set({"n", "x", "o"}, "s", function()
   })
 end)
 
--- Jump backward pass a given by user character.
+-- Jump backward past a given by user character.
 vim.keymap.set({"n", "x", "o"}, "S", function()
   ft.jump({
     direction = "backward",
@@ -69,10 +69,10 @@ end)
 
 </details>
 
-<details><summary>Jump pass any quotes</summary>
+<details><summary>Jump past any quotes</summary>
 
 ```lua
--- Jump forward pass any quotes.
+-- Jump forward past any quotes.
 vim.keymap.set({"n", "x", "o"}, "s", function()
   ft.jump({
     direction = "forward",
@@ -81,7 +81,7 @@ vim.keymap.set({"n", "x", "o"}, "s", function()
   })
 end)
 
--- Jump backward pass any quotes.
+-- Jump backward past any quotes.
 vim.keymap.set({"n", "x", "o"}, "S", function()
   ft.jump({
     direction = "backward",


### PR DESCRIPTION
Thanks for sharing this plugin - it's great! This is just a tiny PR to add some missing commas in the code snippets. It's a minor detail but would save a few seconds to the copy/pasters 🙂 

